### PR TITLE
Added use-css-translate flag

### DIFF
--- a/nzScrollbar.js
+++ b/nzScrollbar.js
@@ -38,7 +38,8 @@
                         ticker,
                         amplitude,
                         target,
-                        timeConstant;
+                        timeConstant,
+                        useCssTranslate = attrs.useCssTranslate !== "false";
 
                     var wheelSpeed = 40;
                     var deferreds = {},
@@ -119,10 +120,18 @@
 
                     function scroll(y) {
                         offset = (y > max) ? max : (y < min) ? min : y;
-                        inner.css({
-                            webkitTransform: 'translateY(' + (-offset) + 'px)',
-                            transform: 'translateY(' + (-offset) + 'px)'
-                        });
+                        
+                        //Check scroll method
+                        if(useCssTranslate) {
+	                        inner.css({
+	                            webkitTransform: 'translateY(' + (-offset) + 'px)',
+	                            transform: 'translateY(' + (-offset) + 'px)'
+	                        });
+                        }
+                        else {
+                        	inner.css({top: -offset + 'px'});
+                        }
+                        
                         indicator.css({
                             webkitTransform: 'translateY(' + (offset / max * ((containerHeight) - parseInt(indicator.css('height')))) + 'px)',
                             transform: 'translateY(' + (offset / max * ((containerHeight) - parseInt(indicator.css('height')))) + 'px)'


### PR DESCRIPTION
Added the attribute use-css-transte (default: true).

There are some situatiosn where using css translate to move the inner
DIV breaks the content, I added a simple flag to use an anternative
method.

use-css-translate="true" -> translate(-offset)
use-css-translate="false" -> top: -offset
