### PR TITLE
add noScroll class to elements that do not overflow

### DIFF
--- a/nzScrollbar.js
+++ b/nzScrollbar.js
@@ -97,6 +97,12 @@
                             display: (containerHeight) / innerHeight >= 1 ? 'none' : 'initial'
                         });
 
+                        /* add noScroll class to elements that won't scroll */
+                        if(containerHeight / innerHeight >= 1) {
+                          indicator.parent().addClass('noScroll');
+                          angular.element(el).addClass('noScroll');
+                        }
+
                     }
 
                     function resize() {


### PR DESCRIPTION
My project design requires that if a scrollbar is enabled, that the indicator and background remains visible. For more flexibility, I've added the noScroll class to elements whose content does not overflow.